### PR TITLE
Restore previous edits API

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -5,7 +5,7 @@ import throttle from 'lodash.throttle';
 import Level from './Level';
 import { RootContext } from './Context';
 import { addOffset, eq } from './utils/path';
-import { getEdits } from './utils/edit';
+import { getEdit } from './utils/edit';
 
 const extractIndexOffset = (e, getIndexOffset) =>
   typeof getIndexOffset === 'function' ? getIndexOffset(e) : getIndexOffset;
@@ -58,7 +58,6 @@ class Root extends React.Component {
     type: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     field: PropTypes.string,
     onChange: PropTypes.func,
-    onEdit: PropTypes.object,
     onError: PropTypes.func,
     mapIn: PropTypes.object,
     mapOut: PropTypes.object
@@ -68,7 +67,6 @@ class Root extends React.Component {
     mapIn: {},
     mapOut: {},
     onChange: () => {},
-    onEdit: {},
     onError: () => {}
   };
 
@@ -222,9 +220,9 @@ class Root extends React.Component {
     }
 
     try {
-      const edits = getEdits(data, path, getDuplicate);
-      if (edits.length) {
-        !dragData && this.runEdits(edits);
+      const edit = getEdit(data, path, getDuplicate);
+      if (edit) {
+        !dragData && this.props.onChange(edit);
         return { path, canDrop: true };
       }
       return { path, canDrop: false };
@@ -232,15 +230,6 @@ class Root extends React.Component {
       !dragData && this.props.onError(e.message);
       return { path, canDrop: false };
     }
-  };
-
-  runEdits = edits => {
-    this.props.onChange(edits);
-    edits.forEach(edit => {
-      const nodeTypeHanders = this.props.onEdit[edit.payload.type] || {};
-      const editTypeHandler = nodeTypeHanders[edit.type] || (() => {});
-      editTypeHandler(edit);
-    });
   };
 
   /**

--- a/src/__tests__/Guration.js
+++ b/src/__tests__/Guration.js
@@ -67,8 +67,7 @@ describe('Guration', () => {
 
     runDrag(nodeProps)(dropProps, inst);
 
-    expect(edit[0].type).toEqual('REMOVE');
-    expect(edit[1].type).toEqual('INSERT');
+    expect(edit.type).toEqual('MOVE');
   });
 
   it('creates INSERT events from mapped drops', () => {
@@ -106,7 +105,7 @@ describe('Guration', () => {
       id: 2
     })(dropProps, inst);
 
-    expect(edit[0]).toEqual({
+    expect(edit).toEqual({
       type: 'INSERT',
       payload: {
         type: 'a',
@@ -161,34 +160,25 @@ describe('Guration', () => {
       id: 4
     })(dropProps, inst);
 
-    expect(edit).toEqual([
-      {
-        type: 'REMOVE',
-        payload: {
-          id: 4,
-          type: 'a',
-          path: {
-            parent: {
-              childrenField: 'children2',
-              id: 3,
-              index: 0,
-              type: 'a'
-            }
+    expect(edit).toEqual({
+      payload: {
+        from: {
+          parent: {
+            childrenField: 'children2',
+            id: 3,
+            index: 0,
+            type: 'a'
           }
-        }
+        },
+        id: 4,
+        to: {
+          parent: { id: 3, index: 0, type: 'a', childrenField: 'children2' },
+          index: 1
+        },
+        type: 'a'
       },
-      {
-        type: 'INSERT',
-        payload: {
-          id: 4,
-          type: 'a',
-          path: {
-            parent: { id: 3, index: 0, type: 'a', childrenField: 'children2' },
-            index: 1
-          }
-        }
-      }
-    ]);
+      type: 'MOVE'
+    });
   });
 
   it('does not allow moves of a node to a subPath of that node', () => {
@@ -281,53 +271,7 @@ describe('Guration', () => {
 
     runDrag(dragProps)(dropProps, inst);
 
-    expect(edit[1].payload.path.index).toBe(2);
-  });
-
-  it('fires onEdits for only the correct edits', () => {
-    let dragProps;
-    let dropProps;
-    let removePayload;
-    let insertPayload;
-    let edit;
-
-    const inst = TestRenderer.create(
-      <Root
-        type="@@ROOT"
-        id="@@ROOT"
-        onEdit={{
-          b: {
-            REMOVE: p => {
-              removePayload = p;
-            },
-            INSERT: p => {
-              insertPayload = p;
-            }
-          }
-        }}
-      >
-        <Level
-          type="b"
-          arr={[{ id: 1 }, { id: 2 }, { id: 3 }]}
-          renderDrop={getDropProps => {
-            dropProps = getDropProps();
-          }}
-        >
-          {(child, getNodeProps, i) => {
-            if (i === 0) {
-              dragProps = getNodeProps();
-            }
-
-            return false;
-          }}
-        </Level>
-      </Root>
-    ).getInstance();
-
-    runDrag(dragProps)(dropProps, inst);
-
-    expect(removePayload.payload.path.index).toBe(undefined);
-    expect(insertPayload.payload.path.index).toBe(2);
+    expect(edit.payload.to.index).toBe(2);
   });
 
   it('does not create MOVE events when moves will have no impact', () => {
@@ -398,7 +342,7 @@ describe('Guration', () => {
   it('creates inserts between roots', () => {
     let nodeProps;
     let dropProps;
-    let edits;
+    let edit;
 
     TestRenderer.create(
       <div>
@@ -420,7 +364,7 @@ describe('Guration', () => {
           type="@@ROOT"
           id="@@ROOT"
           mapIn={{ share: text => ({ id: text, type: 'a' }) }}
-          onChange={e => (edits = e)}
+          onChange={e => (edit = e)}
         >
           <Level
             type="a"
@@ -437,6 +381,6 @@ describe('Guration', () => {
 
     runDrag(nodeProps)(dropProps);
 
-    expect(edits[0].type).toBe('INSERT');
+    expect(edit.type).toBe('INSERT');
   });
 });

--- a/src/edits/index.js
+++ b/src/edits/index.js
@@ -1,24 +1,27 @@
-const remove = (type, id, path) => ({
-  type: 'REMOVE',
+const move = (type, id, dragPath, path, newIndex) => ({
+  type: 'MOVE',
   payload: {
     type,
     id,
-    path: {
-      parent: path[path.length - 2]
+    from: {
+      parent: dragPath[dragPath.length - 2]
+    },
+    to: {
+      parent: path[path.length - 2],
+      index: newIndex
     }
   }
 });
 
-const insert = (type, id, path, index) => ({
+const insert = (type, id, dragPath, newIndex) => ({
   type: 'INSERT',
   payload: {
     type,
     id,
     path: {
-      parent: path[path.length - 2],
-      index
+      parent: dragPath[dragPath.length - 2],
+      index: newIndex
     }
   }
 });
-
-export { remove, insert };
+export { move, insert };

--- a/src/utils/edit.js
+++ b/src/utils/edit.js
@@ -1,7 +1,7 @@
 import { isSubPath, pathForMove, hasMoved } from './path';
-import { remove, insert } from '../edits';
+import { move, insert } from '../edits';
 
-const getEdits = (inputData, inputPath, getDuplicate) =>
+const getEdit = (inputData, inputPath, getDuplicate) =>
   inputData.dropType === 'INTERNAL'
     ? handleMove(inputData.path, inputPath)
     : handleInsert(inputData, inputPath, getDuplicate);
@@ -22,11 +22,8 @@ const handleMove = (prevPath, nextPath) => {
   const { index } = movePath[movePath.length - 1];
 
   return hasMoved(prevPath, nextPath)
-    ? [
-        remove(type, id, prevPath),
-        insert(type, id, movePath, index)
-      ]
-    : [];
+    ? move(type, id, prevPath, movePath, index)
+    : null;
 };
 
 const handleInsert = ({ type: dragType, id }, path, getDuplicate) => {
@@ -40,7 +37,7 @@ const handleInsert = ({ type: dragType, id }, path, getDuplicate) => {
 
   return duplicate
     ? handleMove(duplicate.path, path)
-    : [insert(type, id, path, index)].filter(Boolean);
+    : insert(type, id, path, index);
 };
 
-export { getEdits };
+export { getEdit };


### PR DESCRIPTION
This almost restores the old edits API as we need to know for sure when things are moves rather than inserts for data fetching reasons. Additionally there was still a fair amount of conditional logic outside of the guration lib so it made sense to keep it in once place.

One thing that is different from previous is that edits are no longer wrapped in an array as there was only ever one of them.