### PR TITLE
Allow meta to be passed to input events

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ type Move = {
       },
       index: newIndex
     }
-  }
+  },
+  meta: Object
 };
 ```
 
@@ -58,7 +59,8 @@ type Insert = {
         id: string
       }
     }
-  }
+  },
+  meta: Object
 };
 ```
 
@@ -70,7 +72,7 @@ This is the wrapper around a `Guration` context and [`Levels`](#Level) cannot be
 
 #### Props
 
-##### `id: number | string`
+##### `id: string`
 
 This is the root id that will be used as the parent of the whole tree and will appear in edits that drop into drop zones for the root level of the tree.
 
@@ -90,9 +92,9 @@ This expects a callback function that will receive an of (`edit`)[#Edits] each t
 
 A callback that will recieve strings describing errors regarding invalid drops. For example, dropping an node of one type into a level of another type or dropping an node into a child of itself.
 
-##### `mapIn?: { [string]: string => { id: string, type: string } }`
+##### `mapIn?: { [string]: string => { id: string, type: string, meta?: Object } }`
 
-An object whose keys represent a `type` on `e.dataTransfer.types` that can be handle by the callback that is in the value position of the object. The callback will receive any data that is found when `e.dataTranfer.getData(type)` is called and is expected to return an object of `{ id: string, type: string }` that can be used to validate and then generate an edit in a drop zone.
+An object whose keys represent a `type` on `e.dataTransfer.types` that can be handle by the callback that is in the value position of the object. The callback will receive any data that is found when `e.dataTranfer.getData(type)` is called and is expected to return an object of `{ id: string, type: string }` that can be used to validate and then generate an edit in a drop zone. This object can also have an optional `meta` key to pass through to the any subsequent if required.
 
 ##### `mapOut?: { [string]: (el: Object, type: string, id: string, path: Path[]) => string }`
 
@@ -124,7 +126,7 @@ Again much like `Root` this specifies the `childrenField` field of an edit that 
 
 This is a function that will be used to render the drops between the draggable nodes rendered by `children`. `isOver` is much like `:hover` pseduo-selector except that when `dropOnNode` is true `isTarget` will also be true when that position is the target position for a drop while hovering a node.
 
-##### `getKey: ?(el: T) => number | string`
+##### `getKey: ?(el: T) => string`
 
 A function that returns the key from each object in the array, defaults to `({ id }) => id`
 
@@ -132,7 +134,7 @@ A function that returns the key from each object in the array, defaults to `({ i
 
 Specifying this on a `Level` will ensure that anything below this level that is of the same `type` and has the same `dedupeKey` will act as a move rather than an insert.
 
-##### `getDedupeKey: ?(el: T) => number | string`
+##### `getDedupeKey: ?(el: T) => string`
 
 The function that returns the key for comapring items for deduping, defaults to `getKey`.
 

--- a/src/__tests__/Guration.js
+++ b/src/__tests__/Guration.js
@@ -119,7 +119,51 @@ describe('Guration', () => {
           },
           index: 1
         }
+      },
+      meta: {}
+    });
+  });
+
+  it('creates INSERT events from mapped drops', () => {
+    let dropProps;
+    let edit;
+
+    const inst = TestRenderer.create(
+      <Root
+        type="@@ROOT"
+        id="@@ROOT"
+        onChange={e => (edit = e)}
+        mapIn={{
+          text: str => JSON.parse(str)
+        }}
+      >
+        <Level arr={[{ id: 2 }]} type="a">
+          {() => (
+            <Level
+              arr={[{ id: 1 }]}
+              type="a"
+              field="children"
+              renderDrop={getDropProps => {
+                dropProps = getDropProps();
+              }}
+            >
+              {() => null}
+            </Level>
+          )}
+        </Level>
+      </Root>
+    ).getInstance();
+
+    runDrag('text', {
+      type: 'a',
+      id: 2,
+      meta: {
+        key: 'value'
       }
+    })(dropProps, inst);
+
+    expect(edit.meta).toEqual({
+      key: 'value'
     });
   });
 
@@ -177,7 +221,8 @@ describe('Guration', () => {
         },
         type: 'a'
       },
-      type: 'MOVE'
+      type: 'MOVE',
+      meta: {}
     });
   });
 

--- a/src/edits/index.js
+++ b/src/edits/index.js
@@ -7,7 +7,8 @@ const move = (
   id: string,
   dragPath: Path[],
   path: Path[],
-  newIndex: number
+  newIndex: number,
+  meta: Object = {}
 ) => ({
   type: 'MOVE',
   payload: {
@@ -20,7 +21,8 @@ const move = (
       parent: path[path.length - 2],
       index: newIndex
     }
-  }
+  },
+  meta
 });
 
 type Move = $Call<typeof move, string, string, Path[], Path[], number>;
@@ -29,7 +31,8 @@ const insert = (
   type: string,
   id: string,
   dragPath: Path[],
-  newIndex: number
+  newIndex: number,
+  meta: Object = {}
 ) => ({
   type: 'INSERT',
   payload: {
@@ -39,7 +42,8 @@ const insert = (
       parent: dragPath[dragPath.length - 2],
       index: newIndex
     }
-  }
+  },
+  meta
 });
 
 type Insert = $Call<typeof insert, string, string, Path[], number>;

--- a/src/utils/edit.js
+++ b/src/utils/edit.js
@@ -15,7 +15,7 @@ const getEdit = (
     ? handleMove(inputData.path, inputPath)
     : handleInsert(inputData, inputPath, getDuplicate);
 
-const handleMove = (prevPath, nextPath): ?Edit => {
+const handleMove = (prevPath, nextPath, meta = {}): ?Edit => {
   const { type: dragType, id } = prevPath[prevPath.length - 1];
   const { type } = nextPath[nextPath.length - 1];
 
@@ -31,11 +31,11 @@ const handleMove = (prevPath, nextPath): ?Edit => {
   const { index } = movePath[movePath.length - 1];
 
   return hasMoved(prevPath, nextPath)
-    ? move(type, id, prevPath, movePath, index)
+    ? move(type, id, prevPath, movePath, index, meta)
     : null;
 };
 
-const handleInsert = ({ type: dragType, id }, path, getDuplicate): ?Edit => {
+const handleInsert = ({ type: dragType, id, meta }, path, getDuplicate): ?Edit => {
   const { type, index } = path[path.length - 1];
 
   if (dragType !== type) {
@@ -45,8 +45,8 @@ const handleInsert = ({ type: dragType, id }, path, getDuplicate): ?Edit => {
   const duplicate = getDuplicate(id);
 
   return duplicate
-    ? handleMove(duplicate.path, path)
-    : insert(type, id, path, index);
+    ? handleMove(duplicate.path, path, meta)
+    : insert(type, id, path, index, meta);
 };
 
 export { getEdit };


### PR DESCRIPTION
This allows edits from `mapIn` to be passed a `meta` key to help with any edit operations after a valid drop has happened.